### PR TITLE
Update keys used to store uniqueness constraints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem 'resque-unique_in_queue', github: 'teamintricately/resque-unique_in_queue', ref: 'fdbfe41' # Ensure that only one job per signature can be queued at a time
+gem 'resque-unique_in_queue', '~> 3.0', github: 'teamintricately/resque-unique_in_queue'
 gem 'resque-unique_at_runtime'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem 'resque-unique_in_queue'
+gem 'resque-unique_in_queue', github: 'teamintricately/resque-unique_in_queue', ref: 'fdbfe41' # Ensure that only one job per signature can be queued at a time
 gem 'resque-unique_at_runtime'
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Resque::UniqueByArity
 
-Because some jobs have parameters that you do not want to consider for 
+Because some jobs have parameters that you do not want to consider for
 determination of uniqueness.
 
 NOTE:
 
 I rewrote, and renamed, both `resque_solo` and `resque-lonely_job`, becuase they
- can't be used together.  Why?  Their `redis_key` methods directly conflict, 
+ can't be used together.  Why?  Their `redis_key` methods directly conflict,
  among other more subtle issues.
 
 This gem requires use of my rewritten gems for uniqueness enforcement:
@@ -48,7 +48,6 @@ class MyJob
   end
   include Resque::Plugins::UniqueByArity.new(
     arity_for_uniqueness: 1,
-    lock_after_execution_period: 60,
     runtime_lock_timeout: 60 * 60 * 24 * 5, # 5 days
     unique_at_runtime: true,
     unique_in_queue: true
@@ -92,8 +91,6 @@ Create an initializer (e.g. `config/initializers/resque-unique_by_arity.rb` for 
     config.runtime_lock_timeout = 60 * 60 * 24 * 5
     config.runtime_requeue_interval = 1
     config.unique_at_runtime_key_base = 'r-uar'.freeze
-    config.lock_after_execution_period = 0
-    config.ttl = -1
     config.unique_in_queue_key_base = 'r-uiq'.freeze
     # Debug Mode is preferably set via an environment variable:
     #   to one of 'true', 'arity', or 'arity,queue,runtime' for all three tools:
@@ -105,7 +102,7 @@ Create an initializer (e.g. `config/initializers/resque-unique_by_arity.rb` for 
 ### Per Job Class Configuration
 
 This gem will take care to set the class instance variables (similar to the
- familiar `@queue` class instance variable) that are utilized by 
+ familiar `@queue` class instance variable) that are utilized by
  `resque-unique_in_queue` and `resque-unique_at_runtime` (default values shown):
 
  ```ruby
@@ -115,8 +112,6 @@ This gem will take care to set the class instance variables (similar to the
 @unique_at_runtime_key_base = 'r-uar'.freeze
 
 # For resque-unique_in_queue
-@lock_after_execution_period = 0
-@ttl = -1
 @unique_in_queue_key_base = 'r-uiq'.freeze
 ```
 
@@ -132,8 +127,6 @@ All you need to do is configure this gem accordingly:
     runtime_requeue_interval: 1,
     # would override the global setting, probably a bad idea.
     # unique_at_runtime_key_base: 'r-uar'.freeze,
-    lock_after_execution_period: 0,
-    ttl: -1,
     # would override the global setting, probably a bad idea.
     # unique_in_queue_key_base: 'r-uiq'.freeze
   )
@@ -168,7 +161,7 @@ class MyJob
     # Because the third argument is optional the arity valdiation will not approve.
     # Arguments to be considered for uniqueness should be required arguments.
     # The warning log might look like:
-    # 
+    #
     #    MyJob.perform has the following required parameters: [:my, :cat], which is not enough to satisfy the configured arity_for_uniqueness of 3
   end
   include Resque::Plugins::UniqueByArity.new(
@@ -192,7 +185,6 @@ class MyJob
   end
   include Resque::Plugins::UniqueByArity.new(
     arity_for_uniqueness: 1,
-    lock_after_execution_period: 60,
     unique_at_runtime: true
   )
 end
@@ -233,7 +225,7 @@ end
 ```
 
 #### Oops, I have stale runtime uniqueness keys for MyJob stored in Redis...
- 
+
 Preventing jobs with matching signatures from running, and they never get
 dequeued because there is no actual corresponding job to dequeue.
 
@@ -278,7 +270,7 @@ end
 ```
 
 #### Oops, I have stale Queue Time uniqueness keys...
- 
+
 Preventing jobs with matching signatures from being queued, and they never get
 dequeued because there is no actual corresponding job to dequeue.
 
@@ -358,8 +350,8 @@ class MyJob
     #...
   )
 
-  # Core hashing algorithm for a job used for *all 3 types* of uniqueness 
-  # @return [Array<String, arguments>], where the string is the unique digest, and arguments are the specific args that were used to calculate the digest 
+  # Core hashing algorithm for a job used for *all 3 types* of uniqueness
+  # @return [Array<String, arguments>], where the string is the unique digest, and arguments are the specific args that were used to calculate the digest
   def self.redis_unique_hash(payload)
     #       for how the built-in version works
     # uniqueness_args = payload["args"] # over simplified & ignoring arity
@@ -370,7 +362,7 @@ class MyJob
   def self.unique_in_queue_redis_key_prefix
     # "unique_job:#{self}" # <= default value
   end
-  
+
   def self.unique_in_queue_redis_key(queue, payload)
     # unique_hash, _args_for_uniqueness = redis_unique_hash(payload)
     # "#{unique_in_queue_key_namespace(queue)}:#{unique_in_queue_redis_key_prefix}:#{unique_hash}"
@@ -381,11 +373,11 @@ class MyJob
     # "r-uiq:queue:#{queue}:job" # <= is for unique within queue at queue time
     # "r-uiq:across_queues:job" # <= is for unique across all queues at queue time
   end
-  
+
   def self.runtime_key_namespace
     # "unique_at_runtime:#{self}"
   end
-  
+
   def self.unique_at_runtime_redis_key(*args)
     # unique_hash, _args_for_uniqueness = redis_unique_hash({"class" => self.to_s, "args" => args})
     # key = "#{runtime_key_namespace}:#{unique_hash}" # <= simplified default
@@ -436,7 +428,7 @@ spec.add_dependency 'resque-unique_by_arity', '~> 0.0'
 
 * Copyright (c) 2017 - 2018 [Peter H. Boling][peterboling] of [Rails Bling][railsbling]
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT) 
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 [license]: LICENSE
 [semver]: http://semver.org/

--- a/lib/resque/plugins/unique_by_arity.rb
+++ b/lib/resque/plugins/unique_by_arity.rb
@@ -63,14 +63,6 @@ module Resque
 
         # For resque-unique_in_queue
         #
-        if @configuration.lock_after_execution_period
-          base.instance_variable_set(:@lock_after_execution_period, @configuration.lock_after_execution_period)
-        end
-
-        if @configuration.ttl
-          base.instance_variable_set(:@ttl, @configuration.ttl)
-        end
-
         # Normally doesn't make sense to override per each class because
         #   it wouldn't be able to determine or enforce uniqueness across queues,
         #   and general cleanup of stray keys would be nearly impossible.

--- a/lib/resque/unique_by_arity/configuration.rb
+++ b/lib/resque/unique_by_arity/configuration.rb
@@ -12,7 +12,6 @@ module Resque
       attr_accessor :log_level
       attr_accessor :arity_for_uniqueness
       attr_accessor :arity_validation
-      attr_accessor :lock_after_execution_period
       attr_accessor :runtime_lock_timeout
       attr_accessor :runtime_requeue_interval
       attr_accessor :unique_at_runtime
@@ -20,7 +19,6 @@ module Resque
       attr_accessor :unique_in_queue
       attr_accessor :unique_in_queue_key_base
       attr_accessor :unique_across_queues
-      attr_accessor :ttl
       attr_accessor :base_klass_name
       attr_accessor :debug_mode
 
@@ -31,8 +29,6 @@ module Resque
         @arity_validation = options.key?(:arity_validation) ? options[:arity_validation] : defcon(:arity_validation) || :warning
         raise ArgumentError, "Resque::Plugins::UniqueByArity.new requires arity_validation values of #{arity_validation.inspect}, or a class inheriting from Exception, but the value is #{@arity_validation} (#{@arity_validation.class})" unless VALID_ARITY_VALIDATION_LEVELS.include?(@arity_validation) || !@arity_validation.respond_to?(:ancestors) || @arity_validation.ancestors.include?(Exception)
 
-        @ttl = options.key?(:ttl) ? options[:ttl] : defcon(:ttl) || nil
-        @lock_after_execution_period = options.key?(:lock_after_execution_period) ? options[:lock_after_execution_period] : defcon(:lock_after_execution_period) || nil
         @runtime_lock_timeout = options.key?(:runtime_lock_timeout) ? options[:runtime_lock_timeout] : defcon(:runtime_lock_timeout) || nil
         @runtime_requeue_interval = options.key?(:runtime_requeue_interval) ? options[:runtime_requeue_interval] : defcon(:runtime_requeue_interval) || nil
         @unique_at_runtime = options.key?(:unique_at_runtime) ? options[:unique_at_runtime] : defcon(:unique_at_runtime) || false
@@ -69,9 +65,7 @@ module Resque
           arity_validation: arity_validation,
           base_klass_name: base_klass_name,
           debug_mode: debug_mode,
-          lock_after_execution_period: lock_after_execution_period,
           runtime_lock_timeout: runtime_lock_timeout,
-          ttl: ttl,
           unique_at_runtime: unique_at_runtime,
           unique_in_queue: unique_in_queue,
           unique_across_queues: unique_across_queues

--- a/lib/resque/unique_by_arity/configuration/validator.rb
+++ b/lib/resque/unique_by_arity/configuration/validator.rb
@@ -9,13 +9,11 @@ module Resque
         extend Forwardable
 
         ARITY_FOR_UNIQUENESS_MSG = '[%<job_name>s] :arity_for_uniqueness is set to %<arity_for_uniqueness>d, but no uniqueness enforcement was turned on [:unique_at_runtime, :unique_in_queue, :unique_across_queues]'.freeze
-        LOCK_AFTER_EXEC_PERIOD_MSG = '[%<job_name>s] :lock_after_execution_period is set to %<lock_after_execution_period>d, but :unique_at_runtime is not set'.freeze
         RUNTIME_LOCK_TIMEOUT_MSG = '[%<job_name>s] :runtime_lock_timeout is set to %<runtime_lock_timeout>s, but :unique_at_runtime is not set'.freeze
         RUNTIME_REQUEUE_INTERVAL_MSG = '[%<job_name>s] :runtime_requeue_interval is set to %<runtime_requeue_interval>d, but :unique_at_runtime is not set'.freeze
         CONCURRENT_CONFIG_MSG = '[%<job_name>] :unique_in_queue and :unique_across_queues should not be set at the same time, as :unique_across_queues will always supercede :unique_in_queue'.freeze
 
         private_constant :ARITY_FOR_UNIQUENESS_MSG,
-                         :LOCK_AFTER_EXEC_PERIOD_MSG,
                          :RUNTIME_LOCK_TIMEOUT_MSG,
                          :RUNTIME_REQUEUE_INTERVAL_MSG,
                          :CONCURRENT_CONFIG_MSG
@@ -26,7 +24,6 @@ module Resque
 
         def log_warnings
           validate_arity_for_uniqueness
-          validate_after_execution_period
           validate_runtime_lock_timout
           validate_runtime_requeue_interval
         end
@@ -41,7 +38,6 @@ module Resque
         def_delegators :config,
                        :arity_for_uniqueness,
                        :base_klass_name,
-                       :lock_after_execution_period,
                        :runtime_lock_timeout,
                        :runtime_requeue_interval,
                        :unique_across_queues,
@@ -79,17 +75,6 @@ module Resque
             RUNTIME_LOCK_TIMEOUT_MSG,
             job_name: base_klass_name,
             runtime_lock_timeout: runtime_lock_timeout
-          )
-        end
-
-        def validate_after_execution_period
-          return if default_config_value?(:lock_after_execution_period) ||
-                    (unique_in_queue || unique_across_queues)
-
-          log format(
-            LOCK_AFTER_EXEC_PERIOD_MSG,
-            job_name: base_klass_name,
-            lock_after_execution_period: lock_after_execution_period
           )
         end
 

--- a/lib/resque/unique_by_arity/global_configuration.rb
+++ b/lib/resque/unique_by_arity/global_configuration.rb
@@ -13,8 +13,6 @@ module Resque
       DEFAULT_AT_RUNTIME_KEY_BASE = 'r-uar'.freeze
 
       # For resque-unique_in_queue
-      DEFAULT_LOCK_AFTER_EXECUTION_PERIOD = 0
-      DEFAULT_TTL = -1
       DEFAULT_IN_QUEUE_KEY_BASE = 'r-uiq'.freeze
 
       include Singleton
@@ -33,7 +31,6 @@ module Resque
         @log_level = DEFAULT_LOG_LEVEL
         @arity_for_uniqueness = nil
         @arity_validation = nil
-        @lock_after_execution_period = DEFAULT_LOCK_AFTER_EXECUTION_PERIOD
         @runtime_lock_timeout = DEFAULT_LOCK_TIMEOUT
         @runtime_requeue_interval = DEFAULT_REQUEUE_INTERVAL
         @unique_at_runtime_key_base = DEFAULT_AT_RUNTIME_KEY_BASE
@@ -41,7 +38,6 @@ module Resque
         @unique_at_runtime = false
         @unique_in_queue = false
         @unique_across_queues = false
-        @ttl = DEFAULT_TTL
         if @debug_mode
           # Make sure there is a logger when in debug_mode
           @logger ||= Logger.new(STDOUT)

--- a/lib/resque/unique_by_arity/modulizer.rb
+++ b/lib/resque/unique_by_arity/modulizer.rb
@@ -84,8 +84,9 @@ module Resque
             # @return [String] the key used to enforce loneliness (uniqueness at runtime)
             define_method(:unique_at_runtime_redis_key) do |*args|
               unique_hash, args_for_uniqueness = redis_unique_hash('class' => to_s, 'args' => args)
-              Resque::UniqueByArity.debug("#{Resque::UniqueAtRuntime::PLUGIN_TAG} #{self}.unique_at_runtime_redis_key for #{args_for_uniqueness} is: #{ColorizedString[runtime_key_namespace].yellow}")
-              unique_hash
+              key = "#{self}:#{unique_hash}"
+              Resque::UniqueByArity.debug("#{Resque::UniqueAtRuntime::PLUGIN_TAG} #{self}.unique_at_runtime_redis_key for #{args_for_uniqueness} is: #{ColorizedString[key].yellow}")
+              key
             end
             # @return [Fixnum] number of keys that were deleted
             define_method(:purge_unique_at_runtime_redis_keys) do

--- a/lib/resque/unique_by_arity/version.rb
+++ b/lib/resque/unique_by_arity/version.rb
@@ -1,5 +1,5 @@
 module Resque
   module UniqueByArity
-    VERSION = '3.0.2'.freeze
+    VERSION = '4.0.0'.freeze
   end
 end

--- a/resque-unique_by_arity.gemspec
+++ b/resque-unique_by_arity.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'colorize', '>= 0.8'
   spec.add_runtime_dependency 'resque', '>= 1.2'
-  spec.add_runtime_dependency 'resque-unique_in_queue', '>= 2'
+  spec.add_runtime_dependency 'resque-unique_in_queue', '~> 3.0'
   spec.add_runtime_dependency 'resque-unique_at_runtime', '>= 3'
 
   spec.add_development_dependency 'bundler', '~> 1.16'

--- a/spec/fixtures/unique_fake_job_with_arity.rb
+++ b/spec/fixtures/unique_fake_job_with_arity.rb
@@ -1,0 +1,13 @@
+class UniqueFakeJobWithArity
+  @queue = :normal
+
+  def self.perform(_req, _opts = {})
+    # Does something
+  end
+
+  include Resque::Plugins::UniqueByArity.new(
+    arity_for_uniqueness: 1,
+    unique_at_runtime: true,
+    unique_in_queue: true
+  )
+end

--- a/spec/fixtures/unique_slow_fake_job_with_arity.rb
+++ b/spec/fixtures/unique_slow_fake_job_with_arity.rb
@@ -1,0 +1,13 @@
+class UniqueSlowFakeJobWithArity
+  @queue = :normal
+
+  def self.perform(_req, _opts = {})
+    sleep 0.1
+  end
+
+  include Resque::Plugins::UniqueByArity.new(
+    arity_for_uniqueness: 1,
+    unique_at_runtime: true,
+    unique_in_queue: true
+  )
+end

--- a/spec/resque/plugins/unique_by_arity_spec.rb
+++ b/spec/resque/plugins/unique_by_arity_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Resque::Plugins::UniqueByArity do
 
   context '.unique_in_queue_redis_key' do
     context 'with bogus queue' do
-      it 'gives r-uiq:queue:bogus:job:unique_job:RealFake:ef0f8a28f2c84e48211489121112e67f' do
-        expect(subject.unique_in_queue_redis_key('bogus', class: subject.to_s, args: args)).to eq 'r-uiq:queue:bogus:job:unique_job:RealFake:ef0f8a28f2c84e48211489121112e67f'
+      it 'gives r-uiq:queue:bogus:job:unique_job:RealFake' do
+        expect(subject.unique_in_queue_redis_key('bogus', class: subject.to_s, args: args)).to eq 'r-uiq:queue:bogus:job:unique_job:RealFake'
       end
     end
     context 'when custom unique_at_runtime_key_base' do
@@ -71,8 +71,8 @@ RSpec.describe Resque::Plugins::UniqueByArity do
       end
       let(:args) { [opts] }
 
-      it 'gives defenestrate:queue:bogus:job:unique_job:RealFake:ef0f8a28f2c84e48211489121112e67f' do
-        expect(subject.unique_in_queue_redis_key('bogus', class: subject.to_s, args: args)).to eq 'defenestrate:queue:bogus:job:unique_job:RealFake:b7784ea79e21dc5d1a2fab675a505d53'
+      it 'gives defenestrate:queue:bogus:job:unique_job:RealFake' do
+        expect(subject.unique_in_queue_redis_key('bogus', class: subject.to_s, args: args)).to eq 'defenestrate:queue:bogus:job:unique_job:RealFake'
       end
     end
     context 'when perform has no required args' do
@@ -95,8 +95,8 @@ RSpec.describe Resque::Plugins::UniqueByArity do
       end
       let(:args) { [opts] }
 
-      it 'gives defenestrate:queue:bogus:job:unique_job:RealFake:ef0f8a28f2c84e48211489121112e67f' do
-        expect(subject.unique_in_queue_redis_key('bogus', class: subject.to_s, args: args)).to eq 'defenestrate:queue:bogus:job:unique_job:RealFake:b7784ea79e21dc5d1a2fab675a505d53'
+      it 'gives defenestrate:queue:bogus:job:unique_job:RealFake' do
+        expect(subject.unique_in_queue_redis_key('bogus', class: subject.to_s, args: args)).to eq 'defenestrate:queue:bogus:job:unique_job:RealFake'
       end
     end
   end
@@ -108,8 +108,8 @@ RSpec.describe Resque::Plugins::UniqueByArity do
   end
 
   context '.unique_at_runtime_redis_key' do
-    it 'gives r-uar:RealFake:ef0f8a28f2c84e48211489121112e67f' do
-      expect(subject.unique_at_runtime_redis_key(*args)).to eq 'r-uar:RealFake:ef0f8a28f2c84e48211489121112e67f'
+    it 'gives ef0f8a28f2c84e48211489121112e67f' do
+      expect(subject.unique_at_runtime_redis_key(*args)).to eq 'ef0f8a28f2c84e48211489121112e67f'
     end
     context 'when perform has no required args' do
       let(:instance) do
@@ -130,8 +130,8 @@ RSpec.describe Resque::Plugins::UniqueByArity do
       end
       let(:args) { [opts] }
 
-      it 'gives r-uar:RealFake:b7784ea79e21dc5d1a2fab675a505d53' do
-        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'r-uar:RealFake:b7784ea79e21dc5d1a2fab675a505d53'
+      it 'gives b7784ea79e21dc5d1a2fab675a505d53' do
+        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'b7784ea79e21dc5d1a2fab675a505d53'
       end
     end
     context 'when perform has required args, but arity is 0' do
@@ -153,8 +153,8 @@ RSpec.describe Resque::Plugins::UniqueByArity do
       end
       let(:args) { [opts] }
 
-      it 'gives r-uar:RealFake:b7784ea79e21dc5d1a2fab675a505d53' do
-        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'r-uar:RealFake:b7784ea79e21dc5d1a2fab675a505d53'
+      it 'gives b7784ea79e21dc5d1a2fab675a505d53' do
+        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'b7784ea79e21dc5d1a2fab675a505d53'
       end
     end
     context 'when custom unique_at_runtime_key_base' do
@@ -177,12 +177,12 @@ RSpec.describe Resque::Plugins::UniqueByArity do
       end
       let(:args) { [opts] }
 
-      it 'gives defenestrate:RealFake:b7784ea79e21dc5d1a2fab675a505d53' do
-        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'defenestrate:RealFake:b7784ea79e21dc5d1a2fab675a505d53'
+      it 'gives b7784ea79e21dc5d1a2fab675a505d53' do
+        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'b7784ea79e21dc5d1a2fab675a505d53'
       end
 
-      it 'gives defenestrate:RealFake:b7784ea79e21dc5d1a2fab675a505d53' do
-        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'defenestrate:RealFake:b7784ea79e21dc5d1a2fab675a505d53'
+      it 'gives b7784ea79e21dc5d1a2fab675a505d53' do
+        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'b7784ea79e21dc5d1a2fab675a505d53'
       end
     end
   end

--- a/spec/resque/plugins/unique_by_arity_spec.rb
+++ b/spec/resque/plugins/unique_by_arity_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe Resque::Plugins::UniqueByArity do
   end
 
   context '.unique_at_runtime_redis_key' do
-    it 'gives ef0f8a28f2c84e48211489121112e67f' do
-      expect(subject.unique_at_runtime_redis_key(*args)).to eq 'ef0f8a28f2c84e48211489121112e67f'
+    it 'gives RealFake:ef0f8a28f2c84e48211489121112e67f' do
+      expect(subject.unique_at_runtime_redis_key(*args)).to eq 'RealFake:ef0f8a28f2c84e48211489121112e67f'
     end
     context 'when perform has no required args' do
       let(:instance) do
@@ -130,8 +130,8 @@ RSpec.describe Resque::Plugins::UniqueByArity do
       end
       let(:args) { [opts] }
 
-      it 'gives b7784ea79e21dc5d1a2fab675a505d53' do
-        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'b7784ea79e21dc5d1a2fab675a505d53'
+      it 'gives RealFake:b7784ea79e21dc5d1a2fab675a505d53' do
+        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'RealFake:b7784ea79e21dc5d1a2fab675a505d53'
       end
     end
     context 'when perform has required args, but arity is 0' do
@@ -153,8 +153,8 @@ RSpec.describe Resque::Plugins::UniqueByArity do
       end
       let(:args) { [opts] }
 
-      it 'gives b7784ea79e21dc5d1a2fab675a505d53' do
-        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'b7784ea79e21dc5d1a2fab675a505d53'
+      it 'gives RealFake:b7784ea79e21dc5d1a2fab675a505d53' do
+        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'RealFake:b7784ea79e21dc5d1a2fab675a505d53'
       end
     end
     context 'when custom unique_at_runtime_key_base' do
@@ -177,12 +177,12 @@ RSpec.describe Resque::Plugins::UniqueByArity do
       end
       let(:args) { [opts] }
 
-      it 'gives b7784ea79e21dc5d1a2fab675a505d53' do
-        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'b7784ea79e21dc5d1a2fab675a505d53'
+      it 'gives RealFake:b7784ea79e21dc5d1a2fab675a505d53' do
+        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'RealFake:b7784ea79e21dc5d1a2fab675a505d53'
       end
 
-      it 'gives b7784ea79e21dc5d1a2fab675a505d53' do
-        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'b7784ea79e21dc5d1a2fab675a505d53'
+      it 'gives RealFake:b7784ea79e21dc5d1a2fab675a505d53' do
+        expect(subject.unique_at_runtime_redis_key(*args)).to eq 'RealFake:b7784ea79e21dc5d1a2fab675a505d53'
       end
     end
   end

--- a/spec/resque/unique_by_arity/configuration/validator_spec.rb
+++ b/spec/resque/unique_by_arity/configuration/validator_spec.rb
@@ -60,24 +60,6 @@ describe Resque::UniqueByArity::Configuration::Validator do
       it { expect(Resque::UniqueByArity).to have_received(:log) }
     end
 
-    context 'when lock_after_execution_period is set' do
-      let(:config) do
-        Resque::UniqueByArity::Configuration.new(
-          lock_after_execution_period: 100
-        )
-      end
-
-      subject { described_class.new(config) }
-
-      before do
-        allow(Resque::UniqueByArity).to receive(:log)
-
-        subject.log_warnings
-      end
-
-      it { expect(Resque::UniqueByArity).to have_received(:log) }
-    end
-
     context 'when arity_for_uniqueness is set' do
       let(:config) do
         Resque::UniqueByArity::Configuration.new(

--- a/spec/resque/unique_by_arity/configuration_spec.rb
+++ b/spec/resque/unique_by_arity/configuration_spec.rb
@@ -8,7 +8,6 @@ describe Resque::UniqueByArity::Configuration do
     let(:logger) { Logger.new('/dev/null') }
     let(:arity_for_uniqueness) { 0 }
     let(:arity_validation) { :warning }
-    let(:lock_after_execution_period) { nil }
     let(:runtime_lock_timeout) { 10 }
     let(:runtime_requeue_interval) { 15 }
     let(:unique_at_runtime) { true }
@@ -26,7 +25,6 @@ describe Resque::UniqueByArity::Configuration do
           log_level: log_level,
           arity_for_uniqueness: arity_for_uniqueness,
           arity_validation: arity_validation,
-          lock_after_execution_period: lock_after_execution_period,
           runtime_lock_timeout: runtime_lock_timeout,
           runtime_requeue_interval: runtime_requeue_interval,
           unique_at_runtime: unique_at_runtime,
@@ -67,12 +65,6 @@ describe Resque::UniqueByArity::Configuration do
         subject { instance.arity_validation }
         it 'sets arity_validation' do
           is_expected.to eq(arity_validation)
-        end
-      end
-      context 'lock_after_execution_period option' do
-        subject { instance.lock_after_execution_period }
-        it 'sets lock_after_execution_period' do
-          is_expected.to eq(lock_after_execution_period)
         end
       end
       context 'runtime_lock_timeout option' do
@@ -158,9 +150,7 @@ describe Resque::UniqueByArity::Configuration do
                               arity_validation: arity_validation,
                               base_klass_name: nil, # Not set by initialize!
                               debug_mode: false, # normalized to true || false
-                              lock_after_execution_period: lock_after_execution_period,
                               runtime_lock_timeout: runtime_lock_timeout,
-                              ttl: -1,
                               unique_at_runtime: unique_at_runtime,
                               unique_in_queue: unique_in_queue,
                               unique_across_queues: unique_across_queues

--- a/spec/resque/unique_by_arity_spec.rb
+++ b/spec/resque/unique_by_arity_spec.rb
@@ -21,9 +21,6 @@ RSpec.describe Resque::UniqueByArity do
     it 'has default arity_validation' do
       expect(Resque::UniqueByArity.configuration.arity_validation).to eq(nil)
     end
-    it 'has default lock_after_execution_period' do
-      expect(Resque::UniqueByArity.configuration.lock_after_execution_period).to eq(0)
-    end
     it 'has default runtime_lock_timeout' do
       expect(Resque::UniqueByArity.configuration.runtime_lock_timeout).to eq(60 * 60 * 24 * 5)
     end
@@ -45,9 +42,6 @@ RSpec.describe Resque::UniqueByArity do
     it 'has default unique_across_queues' do
       expect(Resque::UniqueByArity.configuration.unique_across_queues).to eq(false)
     end
-    it 'has default ttl' do
-      expect(Resque::UniqueByArity.configuration.ttl).to eq(-1)
-    end
     it 'has default debug_mode' do
       expect(Resque::UniqueByArity.configuration.debug_mode).to eq(false)
     end
@@ -61,8 +55,6 @@ RSpec.describe Resque::UniqueByArity do
       let(:runtime_lock_timeout) { 10 }
       let(:runtime_requeue_interval) { 4 }
       let(:unique_at_runtime_key_base) { 'abc' }
-      let(:lock_after_execution_period) { 7 }
-      let(:ttl) { 2 }
       let(:unique_in_queue_key_base) { 'def' }
       let(:debug_mode) { true }
       before do
@@ -75,8 +67,6 @@ RSpec.describe Resque::UniqueByArity do
           config.runtime_lock_timeout = runtime_lock_timeout
           config.runtime_requeue_interval = runtime_requeue_interval
           config.unique_at_runtime_key_base = unique_at_runtime_key_base
-          config.lock_after_execution_period = lock_after_execution_period
-          config.ttl = ttl
           config.unique_in_queue_key_base = unique_in_queue_key_base
           # Normally debug mode should be set via an environment variable switch
           #   rather than in the configure block.
@@ -95,8 +85,6 @@ RSpec.describe Resque::UniqueByArity do
         expect(Resque::UniqueByArity.configuration.runtime_lock_timeout).to eq(runtime_lock_timeout)
         expect(Resque::UniqueByArity.configuration.runtime_requeue_interval).to eq(runtime_requeue_interval)
         expect(Resque::UniqueByArity.configuration.unique_at_runtime_key_base).to eq(unique_at_runtime_key_base)
-        expect(Resque::UniqueByArity.configuration.lock_after_execution_period).to eq(lock_after_execution_period)
-        expect(Resque::UniqueByArity.configuration.ttl).to eq(ttl)
         expect(Resque::UniqueByArity.configuration.unique_in_queue_key_base).to eq(unique_in_queue_key_base)
         expect(Resque::UniqueByArity.configuration.debug_mode).to eq(debug_mode)
       end

--- a/spec/resque_spec.rb
+++ b/spec/resque_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+RSpec.describe 'Resque overview' do
+  before do
+    Resque.redis.del(Resque.redis.keys)
+  end
+
+  it 'enqueues jobs' do
+    Resque.enqueue UniqueFakeJobWithArity, 'foo'
+
+    expect(Resque.enqueued?(UniqueFakeJobWithArity, 'foo')).to eq true
+  end
+
+  it 'enqueues the same job with different argument' do
+    Resque.enqueue UniqueFakeJobWithArity, 'foo'
+    Resque.enqueue UniqueFakeJobWithArity, 'bar'
+
+    expect(Resque.enqueued?(UniqueFakeJobWithArity, 'foo')).to eq true
+    expect(Resque.enqueued?(UniqueFakeJobWithArity, 'bar')).to eq true
+
+    queue = UniqueFakeJobWithArity.instance_variable_get(:@queue)
+
+    expect(Resque.size(queue)).to eq 2
+  end
+
+  it 'marks the job as unqueued after it runs' do
+    Resque.enqueue UniqueFakeJobWithArity, 'foo'
+
+    job = Resque.reserve(UniqueFakeJobWithArity.instance_variable_get(:@queue))
+    job.perform
+
+    expect(Resque.enqueued?(UniqueFakeJobWithArity, 'foo')).to eq false
+  end
+
+  it 'locks the queue when the job takes too long to run' do
+    queue = UniqueSlowFakeJobWithArity.instance_variable_get(:@queue)
+
+    Resque.enqueue UniqueSlowFakeJobWithArity, 'foo'
+
+    thread = Thread.new do
+      job, args = Resque.reserve(queue)
+      job.perform(*args)
+    end
+
+    expect(UniqueSlowFakeJobWithArity.queue_locked?('foo')).to be_truthy
+    expect(UniqueSlowFakeJobWithArity.queue_locked?('bar')).to be_falsey
+
+    expect(Resque.size(queue)).to eq 0
+
+    thread.join
+
+    Resque.enqueue UniqueSlowFakeJobWithArity, 'foo'
+
+    expect(Resque.size(queue)).to eq 1
+  end
+end

--- a/spec/resque_spec.rb
+++ b/spec/resque_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 RSpec.describe 'Resque overview' do
   before do
-    Resque.redis.del(Resque.redis.keys)
+    keys = Resque.redis.keys
+    Resque.redis.del(keys) if keys.any?
   end
 
   it 'enqueues jobs' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,9 @@ SimpleCov.start
 # This gem
 require 'resque-unique_by_arity'
 
+require_relative './fixtures/unique_fake_job_with_arity'
+require_relative './fixtures/unique_slow_fake_job_with_arity'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
Update keys used to store uniqueness constraints #1

* Adjust how we define the keys. Unique in queue is now using sets on version 3.0.0.
* Remove `ttl` and `lock_after_execution_period` options passed to Unique in Queue gem.

Please see: https://github.com/teamintricately/resque-unique_in_queue/pull/2